### PR TITLE
Remove unnecessary search names page

### DIFF
--- a/app/scripts/app/common/SideMenuController.js
+++ b/app/scripts/app/common/SideMenuController.js
@@ -43,10 +43,6 @@ angular.module('CommonModule').controller('SideMenuController', [
           {
             title: 'Feedbacks',
             link: 'auth.names.feedbacks'
-          },
-          {
-            title: 'Search',
-            link: 'auth.names.search'
           }
         ]
       }


### PR DESCRIPTION
Premise: There are already two other text boxes on the website for searching. I don't see the need for a dedicated page.