### PR TITLE
Stop using form-encoded functions.

### DIFF
--- a/app/scripts/app/names/NamesService.js
+++ b/app/scripts/app/names/NamesService.js
@@ -103,7 +103,7 @@ angular.module('NamesModule').service('NamesService', [
       */
     this.deleteName = function (entry, fn, status) {
       if (status === 'suggested')
-        return api.delete('/v1/suggestions/' + entry.id).success(function () {
+        return api.deleteJson('/v1/suggestions/' + entry.id).success(function () {
           toastr.success(entry.name + ' with id: ' + entry.id + ' has been deleted successfully');
           return fn();
         }).error(function () {

--- a/app/scripts/app/users/UsersService.js
+++ b/app/scripts/app/users/UsersService.js
@@ -40,7 +40,7 @@ angular.module('UsersModule').service('usersService', [
       return api.get('/v1/auth/users', params);
     };
     this.deleteUser = function (user, fn) {
-      return api.delete('/v1/auth/users/' + user.email, user).success(function () {
+      return api.deleteJson('/v1/auth/users/' + user.email, user).success(function () {
         toastr.success('User account with email ' + user.email + ' has been deleted.');
         return fn();
       });


### PR DESCRIPTION
Using `delete()` sets 'Content-Type' header to 'application/x-www-form-urlencoded' which causes future POST/PUT/PATCH/DELETE requests to the API to fail since the API is expecting JSON requests on all endpoints.