### PR TITLE
Stop updating Name on navigation in Name Edit page.

### DIFF
--- a/app/scripts/app/names/NamesController.js
+++ b/app/scripts/app/names/NamesController.js
@@ -90,7 +90,6 @@ angular.module('NamesModule').controller('NamesAddEntriesCtrl', [
       });
     };
     $scope.goto = function (entry) {
-      namesService.updateName(originalName, $scope.name);
       return $state.go('auth.names.edit_entries', { entry: entry });
     };
     $scope.submit = function () {


### PR DESCRIPTION
Before this change, if the previous/next button was clicked on the dashboard "edit name" page for navigation, the old entry would be updated and thus, disappear from the index.

We are removing this behaviour because it is unexpected behaviour. It is not intuitive that simply navigating from one name to the next could change the state of the name.

As such, this behaviour has been removed in this PR.